### PR TITLE
Do ALL build work in the build image, output image just has exe.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,15 @@ RUN mkdir -p $LEIN_INSTALL \
   && mkdir -p /usr/share/java \
   && mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
 
-RUN wget https://github.com/oracle/graal/releases/download/vm-1.0.0-rc1/graalvm-ce-1.0.0-rc1-linux-amd64.tar.gz
-RUN tar zxvf graalvm-ce-1.0.0-rc1-linux-amd64.tar.gz
-RUN rm graalvm-ce-1.0.0-rc1-linux-amd64.tar.gz
+RUN wget https://github.com/oracle/graal/releases/download/vm-1.0.0-rc1/graalvm-ce-1.0.0-rc1-linux-amd64.tar.gz && \
+    tar zxvf graalvm-ce-1.0.0-rc1-linux-amd64.tar.gz && \
+    mv graalvm-1.0.0-rc1 /opt/graal && \
+    rm graalvm-ce-1.0.0-rc1-linux-amd64.tar.gz
+
+RUN apt-get update && \
+    apt-get -y install \
+            gcc \
+            zlib1g-dev
 
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
@@ -35,40 +41,14 @@ RUN lein jlink init
 RUN lein jlink assemble
 RUN lein jlink package
 
+RUN mkdir -p test src dev-resources resources target target/classes && \
+    /opt/graal/bin/native-image -H:+ReportUnsupportedElementsAtRuntime -cp `lein cp`:target/jlink/hey.jar hey.core 
+
 #NOTE: If you run jlink on ubuntu, you can't use the same jre on alpine, they have incompatible libc libraries!
 
 FROM debian:sid-slim
 
-ENV LEIN_VERSION=2.8.1
-ENV LEIN_INSTALL=/usr/local/bin/
+RUN mkdir -p /opt/hey
+COPY --from=build /usr/src/app/hey.core /opt/hey
 
-# Download Leiningen for the final product
-RUN yes | apt-get update
-RUN yes | apt-get install gcc
-RUN yes | apt-get install zlib1g-dev
-RUN yes | apt-get install wget
-
-COPY --from=build /usr/src/app/target/jlink /opt/hey
-COPY --from=build /usr/src/app/graalvm-1.0.0-rc1 /opt/graal
-COPY --from=build /root/.m2 /root/.m2
-WORKDIR /opt/hey
-ENV PATH=$PATH:/opt/hey/bin
-ENV LEIN_VERSION=2.8.1
-ENV LEIN_INSTALL=/usr/local/bin/
-
-# Download the whole repo as an archive
-RUN mkdir -p $LEIN_INSTALL \
-  && wget -q https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein-pkg \
-  && mv lein-pkg $LEIN_INSTALL/lein \
-  && chmod 0755 $LEIN_INSTALL/lein \
-  && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip \
-  && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc \
-  && rm leiningen-$LEIN_VERSION-standalone.zip.asc \
-  && mkdir -p /usr/share/java \
-  && mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
-RUN mkdir /opt/hey/test /opt/hey/src /opt/hey/dev-resources /opt/hey/resources /opt/hey/target /opt/hey/target/classes  \
-    && echo '(defproject dummy "" :dependencies [[org.clojure/clojure "1.9.0"]])' > project.clj \
-    && /opt/graal/bin/native-image -H:+ReportUnsupportedElementsAtRuntime -cp `lein cp`:hey.jar hey.core
-RUN rm hey.jar
 ENTRYPOINT /opt/hey/hey.core
-


### PR DESCRIPTION
Simplify the Dockerfile to do all build work in the build image, and only copy the exe over to the resulting output image. That's as slim as it gets!